### PR TITLE
fix: use correct logging message on server start

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,4 @@ app.get('/', (req, res, next) => res.status(200).json({ message: 'OK' }))
 
 app.get('/health', (req, res, next) => res.status(200).json({ message: 'OK' }))
 
-app.listen(3000, () => console.log('Server up and listening on port 3000'))
+app.listen(3000, () => console.log('Server ready to accept requests'))


### PR DESCRIPTION
Let's pretend that the logging message being different was considered a bug. This change represents an example of what customers would see for a bugfix type with release-please.