### PR TITLE
feat!: added `timestamp` field to API response

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const bodyParser = require('body-parser')
 const app = express()
 app.use(bodyParser.json())
 
-app.get('/', (req, res, next) => res.status(200).json({ message: 'OK' }))
+app.get('/', (req, res, next) => res.status(200).json({ msg: 'OK', timestamp: Date.now() }))
 
-app.get('/health', (req, res, next) => res.status(200).json({ message: 'OK' }))
+app.get('/health', (req, res, next) => res.status(200).json({ msg: 'OK', timestamp: Date.now() }))
 
 app.listen(3000, () => console.log('Server up and listening on port 3000'))


### PR DESCRIPTION
BREAKING CHANGE: `message` field has been renamed to `msg`

Let's pretend that in order to add the `timestamp` field, we had to also change the `message` field to `msg`. The addition of a new field to an API reponse body would be considered a feature, but changing an existing key would be a breaking change. This changeset represents both what a customer would see when there's a new feature, but also when there's a breaking change.