### PR TITLE
chore: removed unused keys from eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,11 +5,7 @@ module.exports = {
     node: true
   },
   extends: 'standard',
-  overrides: [
-  ],
   parserOptions: {
     ecmaVersion: 'latest'
-  },
-  rules: {
   }
 }


### PR DESCRIPTION
keeping keys in that are empty is unnecessary and confusing